### PR TITLE
Set Default EM System

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 Code levarages `astropy.units.core.Unit` and `astropy.units.quantity.Quantity` objects.
 
 1. Run `import natpy`.
-2. Access physical constants with symbol within `const`:
+1. Access physical constants with symbol within `const`:
 
    ```
    >>> import natpy as nat
@@ -30,7 +30,7 @@ Code levarages `astropy.units.core.Unit` and `astropy.units.quantity.Quantity` o
 
    ```
 
-3. Access units with symbol. Combine with values or `numpy` objects to form quantities:
+1. Access units with symbol. Combine with values or `numpy` objects to form quantities:
 
    ```
    >>> nat.m
@@ -43,9 +43,9 @@ Code levarages `astropy.units.core.Unit` and `astropy.units.quantity.Quantity` o
    <Quantity 500. MeV>
    ```
 
-4. Specify base of natural units with `natpy.set_active_units()`. Pass a string corresponding to a list of default natural units, or a list of physical constants to set your own. The list of default bases may be found in `natpy/default_values.py`.
+1. Specify base of natural units with `natpy.set_active_units()`. Pass a string corresponding to a list of default natural units, or a list of physical constants to set your own. The list of default bases may be found in `natpy/default_values.py`. The default sets c = ℏ = ε₀ = 1.
 
-5. Run `natpy.convert()` to convert between units, including necessary factors of natural units. Pass just unit objects to obtain conversion factors. Pass quantity objects to perform conversions. E.g.
+1. Run `natpy.convert()` to convert between units, including necessary factors of natural units. Pass just unit objects to obtain conversion factors. Pass quantity objects to perform conversions. E.g.
 
    ```
    >>> import natpy as nat
@@ -68,9 +68,9 @@ Code levarages `astropy.units.core.Unit` and `astropy.units.quantity.Quantity` o
    <Quantity 1.79926309e-13 J>
    ```
 
-Note: Summing quantities of compatible units results in a quantity with the first terms units.
+   Note: Summing quantities of compatible units results in a quantity with the first terms units.
 
-6. `natpy.convert()` may also be accessed as a method for unit or quantity objects.
+1. `natpy.convert()` may also be accessed as a method for unit or quantity objects.
 
    ```
    >>> import natpy as nat
@@ -82,4 +82,28 @@ Note: Summing quantities of compatible units results in a quantity with the firs
    <Quantity 5.06773072 1 / fm>
    ```
 
-7. See `examples/conversion.py` for more examples.
+1. Electromagnetic constants are defined in the SI system by default:
+
+   ```
+   >>> nat.const.e
+   <<class 'astropy.constants.codata2018.EMCODATA2018'> name='Electron charge' value=1.602176634e-19 uncertainty=0.0 unit='C' reference='CODATA 2018'>
+   ```
+
+   Values may be accessed in other systems as attributes of the `nat.const.cgs` submodule:
+
+   ```
+   >>> nat.const.cgs.e.gauss
+   <<class 'astropy.constants.codata2018.EMCODATA2018'> name='Electron charge' value=4.803204712570263e-10 uncertainty=0.0 unit='Fr' reference='CODATA 2018'>
+   ```
+
+   The default system may be changed using `natpy.set_active_em_system()`, with arguments `si`, `gauss`, `esu` or `emu`:
+
+   ```
+   >>> nat.set_active_em_system('gauss')
+   >>> nat.const.e
+   <<class 'astropy.constants.codata2018.EMCODATA2018'> name='Electron charge' value=4.803204712570263e-10 uncertainty=0.0 unit='Fr' reference='CODATA 2018'>
+   ```
+
+1. Dimensionless unscales quantities may be constructed using `natpy.dimensionless_unscaled`, which is also bound to `natpy.dimensionless`, `natpy.unitless` and `natpy.one`, for added usability.
+
+1. See `examples/conversion.py` for more examples.

--- a/natpy/__init__.py
+++ b/natpy/__init__.py
@@ -8,7 +8,7 @@ from astropy.units.core import UnitBase
 from astropy.units.quantity import Quantity
 from astropy.units import *
 from .auto_convert_add import convert_ufunc
-
+from .em_system import RedefineNamespace
 
 UnitBase.convert = convert
 Quantity.convert = convert
@@ -17,4 +17,8 @@ set_active_units("hbar_c_eps0")
 # Add functionality for auto converting compatible sums
 Quantity.__array_ufunc__ = auto_convert_add.convert_ufunc
 
-const.set_active_em_system("si")
+
+def set_active_em_system(mode): RedefineNamespace(mode, const)
+
+
+set_active_em_system('si')

--- a/natpy/__init__.py
+++ b/natpy/__init__.py
@@ -1,3 +1,4 @@
+import sys
 from .convert import convert
 
 from .default_values import default_conventions
@@ -8,9 +9,12 @@ from astropy.units.quantity import Quantity
 from astropy.units import *
 from .auto_convert_add import convert_ufunc
 
+
 UnitBase.convert = convert
 Quantity.convert = convert
-set_active_units("hbar_c")
+set_active_units("hbar_c_eps0")
 
 # Add functionality for auto converting compatible sums
 Quantity.__array_ufunc__ = auto_convert_add.convert_ufunc
+
+const.set_active_em_system("si")

--- a/natpy/constants.py
+++ b/natpy/constants.py
@@ -1,7 +1,7 @@
 import numpy
 from astropy import units as u
 from astropy import constants as const
-
+from .em_system import set_active_em_system
 """
 Library of Physical Constants. May be updated/added to as necessary
 """

--- a/natpy/constants.py
+++ b/natpy/constants.py
@@ -1,7 +1,6 @@
 import numpy
 from astropy import units as u
 from astropy import constants as const
-from .em_system import set_active_em_system
 """
 Library of Physical Constants. May be updated/added to as necessary
 """

--- a/natpy/convert.py
+++ b/natpy/convert.py
@@ -107,6 +107,5 @@ def convert(initial_unit, target_unit):
             return QuantityConvert(initial_unit, target_unit)
         else:  # is astropy.units.core.Unit from prev check
             return UnitConvert(initial_unit, target_unit)
-
     except Exception as e:
         raise e

--- a/natpy/custom_units.py
+++ b/natpy/custom_units.py
@@ -1,0 +1,7 @@
+import astropy.units
+
+"""Some extra units, added on request."""
+
+one = astropy.units.dimensionless_unscaled
+unitless = astropy.units.dimensionless_unscaled
+dimensionless = astropy.units.dimensionless_unscaled

--- a/natpy/default_values.py
+++ b/natpy/default_values.py
@@ -9,7 +9,7 @@ Library of default natural bases, and the method to set base.
 
 # Default Nautral Unit Conventions
 default_conventions = {
-    "hbar_c": [const.hbar, const.c],
+    "hbar_c_eps0": [const.hbar, const.c, const.eps0],
     "HEP": [const.c, const.hbar, const.k_B],
     "atomic": [const.e, const.m_e, const.hbar, const.k_B],
     "planck": [const.c, const.hbar, const.G, const.k_B],

--- a/natpy/em_system.py
+++ b/natpy/em_system.py
@@ -2,15 +2,21 @@ import inspect
 import sys
 from astropy.constants import EMConstant
 """Set the active system for Electromagnetic constants (e, eps0, mu0 etc.)
-Overrides the base namespace for each EM constant with the selected system 
+Overrides the base namespace for each EM constant with the selected system
 value. Other systems can be accesses through subnamespace as in Astropy
 
-E.g. If set to si, natpy.const.e.si -> natpy.const.e, 
+E.g. If set to si, natpy.const.e.si -> natpy.const.e,
                but natpy.const.e.gauss -> natpy.const.e.gauss"""
 
 
-def set_active_em_system(mode):
-    caller_name = inspect.currentframe().f_back.f_globals['__name__']
-    for k, v in sys.modules[caller_name].__dict__.items():
+def RedefineNamespace(mode, const_module):
+    for k, v in const_module.__dict__.items():
         if issubclass(type(v), EMConstant):
-            sys.modules[caller_name].__dict__[k] = getattr(v, mode)
+            try:
+                const_module.__dict__[k] = (
+                    getattr(const_module.si.__dict__[k], mode)
+                )
+            except AttributeError:
+                pass  # Wont work if that constant has no attribute of mode
+            # In future will possibly add extra methods to obtain system
+            # dependent def, but for now this works

--- a/natpy/em_system.py
+++ b/natpy/em_system.py
@@ -1,0 +1,16 @@
+import inspect
+import sys
+from astropy.constants import EMConstant
+"""Set the active system for Electromagnetic constants (e, eps0, mu0 etc.)
+Overrides the base namespace for each EM constant with the selected system 
+value. Other systems can be accesses through subnamespace as in Astropy
+
+E.g. If set to si, natpy.const.e.si -> natpy.const.e, 
+               but natpy.const.e.gauss -> natpy.const.e.gauss"""
+
+
+def set_active_em_system(mode):
+    caller_name = inspect.currentframe().f_back.f_globals['__name__']
+    for k, v in sys.modules[caller_name].__dict__.items():
+        if issubclass(type(v), EMConstant):
+            sys.modules[caller_name].__dict__[k] = getattr(v, mode)


### PR DESCRIPTION
Added functionality to set the EM constants in the natpy.const namespace to those of a chosen system, with the default being 'si'. The user may select a different system, or may obtain constants in other systems explicitly and individually. Updated readme to include details on this change.